### PR TITLE
Add Testing Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.log
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 node_modules
+dist/test.js

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ new Anchorage('.Post', {
 1. Clone the repository
 2. Run `npm install; npm run bundle`
 
+
+### Testing
+
+This project uses [testem](https://github.com/testem/testem) to run tests in your browser. Fire it up in CI mode using `npm test`. Alternatively, you can run `npm test:watch` and point your favorite browser to [http://localhost:7357](http://localhost:7357) to run in TDD mode.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -21,8 +21,6 @@ class Anchorage {
       this.setter(headlines[i], ref)
       this.link(headlines[i], this.element(headlines[i].getAttribute('id')))
     }
-
-    console.log(options)
   }
 
   // Collects All the Headlines

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "bundle": "babel index.js -o ./dist/anchorage.min.js",
     "prepublish": "npm run bundle",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "testem ci -P 5",
+    "test:after": "rimraf dist/test.js",
+    "test:before": "webpack"
   },
   "repository": {
     "type": "git",
@@ -21,8 +23,14 @@
   "homepage": "https://github.com/charlespeters/anchorage#readme",
   "devDependencies": {
     "babel-cli": "^6.14.0",
+    "babel-core": "^6.14.0",
+    "babel-loader": "^6.2.5",
     "babel-preset-babili": "0.0.2",
-    "babel-preset-es2015": "^6.14.0"
+    "babel-preset-es2015": "^6.14.0",
+    "rimraf": "^2.5.4",
+    "tape": "^4.6.0",
+    "testem": "^1.10.4",
+    "webpack": "^1.13.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prepublish": "npm run bundle",
     "test": "testem ci -P 5",
     "test:after": "rimraf dist/test.js",
-    "test:before": "webpack"
+    "test:before": "webpack",
+    "test:watch": "testem"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,40 @@
 import Anchorage from './index.js';
 import tape from 'tape';
 
+const TEST_SELECTOR = '#anchorage-test';
+
+tape('setup', t => {
+  const testEl = document.createElement('div');
+  testEl.id = TEST_SELECTOR.slice(1);
+  document.body.appendChild(testEl);
+  t.end();
+});
+
+tape('Anchorage :: constructor', t => {
+  const a1 = new Anchorage(TEST_SELECTOR);
+  const a2 = new Anchorage(TEST_SELECTOR, {
+    headlines: 'h1, h2',
+    linkClass: 'test-link-class',
+  });
+
+  t.ok(a1.options.linkClass, 'sets default linkClass option');
+  t.ok(a1.options.headlines, 'sets default headlines option');
+  t.equal(
+    a2.options.linkClass,
+    'test-link-class',
+    'sets linkClass option via arg'
+  );
+  t.equal(
+    a2.options.headlines,
+    'h1, h2',
+    'sets headlines option via arg'
+  );
+  t.end();
+});
+
+tape('teardown', t => {
+  const testEl = document.querySelector(TEST_SELECTOR);
+  testEl.parentNode.removeChild(testEl);
+  t.end();
+});
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+import Anchorage from './index.js';
+import tape from 'tape';
+

--- a/testem.json
+++ b/testem.json
@@ -1,0 +1,12 @@
+{
+  "after_tests": "npm run test:after",
+  "before_tests": "npm run test:before",
+  "framework": "tap",
+  "src_files": [
+    "index.js",
+    "test.js"
+  ],
+  "serve_files": [
+    "dist/test.js"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  bail: true,
+  devtool: "inline-source-map",
+  entry: {
+    test: './test.js',
+  },
+  node: {
+    fs: 'empty',
+  },
+  output: {
+    filename: '[name].js',
+    path: './dist',
+  },
+  module: {
+    loaders: [{
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel', // 'babel-loader' is also a legal name to reference
+        query: {
+          presets: ['es2015']
+        }
+      } 
+    ],
+  },
+};
+


### PR DESCRIPTION
- **Problem:** There’s no tests!
- **Solution:** Wire up basic testing with [tape](https://www.npmjs.com/package/tape), [webpack](https://webpack.github.io/) and [testem](https://github.com/testem/testem)

What’s happening when you run `npm test`:
1. Webpack builds _test.js_ and puts it in _dist/test.js_.
2. The test adds a `div` for testing (the “setup”), then removes it when all the tests are down (the “teardown”).
3. testem fires up all the browsers it can find on your machine and runs _dist/test.js_ in them. It prints the output to the console, them removes _dist/test.js_.
